### PR TITLE
feat: DeleteReasonModal컴포넌트에 props로 option 전달(#34)

### DIFF
--- a/src/components/common/DeleteReasonModal.tsx
+++ b/src/components/common/DeleteReasonModal.tsx
@@ -2,9 +2,10 @@ import { useEffect, useRef, useState } from 'react'
 
 type DeleteReasonModalProps = {
   options: string[]
+  defaultValue: string
 }
 
-function DeleteReasonModal({ options }: DeleteReasonModalProps) {
+function DeleteReasonModal({ options, defaultValue }: DeleteReasonModalProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -28,9 +29,9 @@ function DeleteReasonModal({ options }: DeleteReasonModalProps) {
       {/* 선택 영역 */}
       <div
         onClick={() => setIsOpen(!isOpen)}
-        className="flex h-9 cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-2 text-sm outline-1 outline-gray-300"
+        className={`flex h-9 cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-2 text-sm outline-1 outline-gray-300 ${!selected ? 'text-gray-500' : ''}`}
       >
-        {selected ?? '탈퇴 사유를 선택해주세요.'}
+        {selected ?? defaultValue}
         <span>▾</span>
       </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 이슈 번호(#34)

- DeleteReasonModal 컴포넌트에 props로 options 전달하도록 변경

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

수정 전) placeholder 색상 검정
<img width="433" height="387" alt="Screenshot 2025-11-28 at 2 37 07 PM" src="https://github.com/user-attachments/assets/d147e6da-f458-4237-a55c-70b6ef24de3c" />

수정 후) placeholder 색상 text-gray-500
https://github.com/user-attachments/assets/da4ba7f5-47c4-4f14-b30d-001b862d4119




- 주요 변경사항
  - 기존: DeleteReasonModal 내부에서 OPTIONS 상수를 정의하여 탈퇴 사유 처리
  - 변경: 외부에서 props로 options 전달
  - placeholder를 "탈퇴 사유를 선택해주세요"로 변경 (기존은 OPTIONS[0] 표시)

## 🔍 테스트 항목

> 완료된 테스트 및 추가 테스트가 필요한 항목

- [ ] option 클릭 시 selected 상태가 올바르게 변경되는지 확인

## ✅ 체크리스트

> PR 작성 시 확인해야 할 사항

- [ ] 기능이 정상적으로 동작하는가?
- [ ] 코드 컨벤션을 준수하였는가?
- [ ] 불필요한 코드 (console.log, 미사용 변수 등)가 없는가?
- [ ] 가독성을 고려하여 적절한 주석을 추가하였는가?
- [ ] 브랜치를 main이 아닌 dev로 설정하였는가?

## 💬 기타

```
const OPTIONS = [
  '더 이상 필요하지 않음',
  '흥미/관심 부족',
  '사용이 너무 어려움',
  '더 나은 서비스 발견',
  '개인 정보 문제',
  '서비스 품질 불량',
  '기술적 문제',
  '콘텐츠 부족',
  '기타',
]
```
- OPTIONS상수 첨부합니다 ( constant에 넣을까 고민했지만 외부에서 그냥 관리할 수도 있을 것 같아서..)
- 생각해보니 refactor인데 feature로 브랜치를 팠네요..ㅎ
