### PR TITLE
feat: 토스트 위치를 페이지별로 분기 처리(#67)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,16 @@
 import AppRoutes from '@/routes/AppRoutes'
+import { useLocation } from 'react-router'
+import { ToastContainer } from 'react-toastify'
 
 function App() {
-  return <AppRoutes />
+  const { pathname } = useLocation()
+
+  const isSpecialPage = pathname.startsWith('/mypage')
+  return (
+    <>
+      <ToastContainer position={isSpecialPage ? 'top-left' : 'top-center'} />
+      <AppRoutes />
+    </>
+  )
 }
 export default App

--- a/src/components/common/toast/Toast.tsx
+++ b/src/components/common/toast/Toast.tsx
@@ -2,7 +2,6 @@ import { toast, type ToastOptions, Slide } from 'react-toastify'
 import { ToastAlert } from '@/components/common/toast/ToastAlert'
 
 const defaultOptions: ToastOptions = {
-  position: 'top-left',
   autoClose: 5000,
   hideProgressBar: false,
   closeOnClick: false,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,6 @@ import App from './App.tsx'
 import { BrowserRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import '@/index.css'
-import { ToastContainer } from 'react-toastify'
 // MSW 워커를 활성화하는 함수(개발환경에서만 실행)
 async function enableMocking() {
   if (import.meta.env.MODE !== 'development') {
@@ -27,7 +26,6 @@ enableMocking().then(() => {
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <App />
-          <ToastContainer />
         </BrowserRouter>
       </QueryClientProvider>
     </StrictMode>


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 이슈 번호(#67)

- 토스트 위치를 페이지별로 분기 처리

## 📝 작업 내용

> 이번 
<img width="600" height="701" alt="Screenshot 2025-12-03 at 11 31 52 AM" src="https://github.com/user-attachments/assets/069cccf9-3dce-4469-82cc-7c30be669bfb" />
PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 구현 기능 요약
 - `<ToastContainer position={isSpecialPage ? 'top-left' : 'top-center'} />`적용
 - 기존 defaultOptions에서 position이 top-left로 고정되어 있던 문제를 해결하고 useLocation을 활용해 페이지별로 토스트 위치를 동적으로 조정할 수 있도록 구현

- 주요 변경사항
  - 마이페이지에서는 top-left 그 외 모든 페이지에서는 top-center로 토스트가 표시되도록 분기 처리

## 🔍 테스트 항목

> 완료된 테스트 및 추가 테스트가 필요한 항목

- [ ] 회원가입 페이지에서 토스트가 top-center 위치에 정상적으로 노출되는지 확인

## ✅ 체크리스트

> PR 작성 시 확인해야 할 사항

- [ ] 기능이 정상적으로 동작하는가?
- [ ] 코드 컨벤션을 준수하였는가?
- [ ] 불필요한 코드 (console.log, 미사용 변수 등)가 없는가?
- [ ] 가독성을 고려하여 적절한 주석을 추가하였는가?
- [ ] 브랜치를 main이 아닌 dev로 설정하였는가?

## 💬 기타

- 마이페이지 및 탈퇴 회원 복구 모달에서 토스트 위치가 정상적으로 표시되는지 사용 시 한 번씩만 확인 부탁드립니다!
