### PR TITLE
fix: 회원가입 닉네임 중복 error response schema 수정(#93)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -8,12 +8,15 @@ export const axiosInstance = axios.create({
   },
 })
 
-// response.data를 직접 throw
+// response.data에 statusCode를 추가해서 throw
 axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.data) {
-      return Promise.reject(error.response.data)
+      return Promise.reject({
+        ...error.response.data,
+        statusCode: error.response.status,
+      })
     }
     return Promise.reject(error)
   }

--- a/src/mocks/handlers/auth/signupHandler.ts
+++ b/src/mocks/handlers/auth/signupHandler.ts
@@ -18,7 +18,6 @@ export const signupHandlers = [
     if (!nickname) {
       return HttpResponse.json(
         {
-          statusCode: 400,
           error_detail: {
             nickname: ['이 필드는 필수 항목입니다.'],
           },
@@ -31,7 +30,6 @@ export const signupHandlers = [
     if (nickname === userInfo.nickname) {
       return HttpResponse.json(
         {
-          statusCode: 409,
           error_detail: '중복된 닉네임이 존재합니다.',
         },
         { status: 409 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 이슈 번호(#93)

- 회원가입 닉네임 중복 error response schema 수정

## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)

- 주요 변경사항
   - 닉네임 중복 오류 응답 스키마를 서버 명세에 맞게 수정
   - axios 인터셉터에서 error.response.status 값을 statusCode로 저장하도록 개선

## 🔍 테스트 항목

> 완료된 테스트 및 추가 테스트가 필요한 항목

- [ ] 테스트 1
- [ ] 테스트 2

## ✅ 체크리스트

> PR 작성 시 확인해야 할 사항

- [ ] 기능이 정상적으로 동작하는가?
- [ ] 코드 컨벤션을 준수하였는가?
- [ ] 불필요한 코드 (console.log, 미사용 변수 등)가 없는가?
- [ ] 가독성을 고려하여 적절한 주석을 추가하였는가?
- [ ] 브랜치를 main이 아닌 dev로 설정하였는가?

## 💬 기타

- 어려웠던 부분

- 고려해야할 부분
