### PR TITLE
fix: 이메일/전화번호 400 에러 메시지 화면 표시(#175)

### DIFF
--- a/src/api/auth/signup.ts
+++ b/src/api/auth/signup.ts
@@ -1,5 +1,5 @@
 import type {
-  ResNickname,
+  ResDetail,
   ReqCodeWithEmail,
   ReqCodeWithPhone,
   ReqEmailOnly,
@@ -13,7 +13,7 @@ import { API_PATHS } from '@/constant/api'
 // 닉네임 중복 확인
 export const checkNickname = async (
   data: ReqNicknameOnly
-): Promise<ResNickname> => {
+): Promise<ResDetail> => {
   const res = await axiosInstance.get(API_PATHS.SIGNUP.NICKNAME_CHECK.GET, {
     params: data,
   })
@@ -21,7 +21,7 @@ export const checkNickname = async (
 }
 
 // 이메일 전송
-export const sendEmail = async (data: ReqEmailOnly) => {
+export const sendEmail = async (data: ReqEmailOnly): Promise<ResDetail> => {
   const res = await axiosInstance.post(API_PATHS.SIGNUP.EMAIL_SEND.POST, data)
 
   return res.data
@@ -35,7 +35,7 @@ export const verifyEmailCode = async (data: ReqCodeWithEmail) => {
 }
 
 // SMS 전송
-export const sendSms = async (data: ReqPhoneOnly) => {
+export const sendSms = async (data: ReqPhoneOnly): Promise<ResDetail> => {
   const res = await axiosInstance.post(API_PATHS.SIGNUP.SMS_SEND.POST, data)
 
   return res.data

--- a/src/hooks/quries/auth/useSignup.ts
+++ b/src/hooks/quries/auth/useSignup.ts
@@ -6,12 +6,18 @@ import {
   verifyEmailCode,
   verifySmsCode,
 } from '@/api/auth/signup'
-import type { ApiError, ResNickname, ReqNicknameOnly } from '@/types/signup'
+import type {
+  ApiError,
+  ReqNicknameOnly,
+  ReqEmailOnly,
+  ResDetail,
+  ReqPhoneOnly,
+} from '@/types/signup'
 import { useMutation } from '@tanstack/react-query'
 
 // 닉네임 중복 확인
 export const useCheckNickname = () => {
-  return useMutation<ResNickname, ApiError, ReqNicknameOnly>({
+  return useMutation<ResDetail, ApiError, ReqNicknameOnly>({
     mutationFn: checkNickname,
     retry: false,
   })
@@ -19,7 +25,7 @@ export const useCheckNickname = () => {
 
 // 이메일 전송
 export const useSendEmail = () => {
-  return useMutation({
+  return useMutation<ResDetail, ApiError, ReqEmailOnly>({
     mutationFn: sendEmail,
   })
 }
@@ -33,7 +39,7 @@ export const useVerifyEmailCode = () => {
 
 // SMS 전송
 export const useSendSms = () => {
-  return useMutation({
+  return useMutation<ResDetail, ApiError, ReqPhoneOnly>({
     mutationFn: sendSms,
   })
 }

--- a/src/pages/signupPage.tsx
+++ b/src/pages/signupPage.tsx
@@ -118,9 +118,14 @@ function SignupPage() {
           setIsEmailSent(true)
           setEmailSendError(null)
         },
-        onError: () => {
+        onError: (error) => {
           setIsEmailSent(false)
-          setEmailSendError('이메일 전송에 실패했습니다.')
+          if (error.statusCode === 400) {
+            const errorMsg = Object.values(error.error_detail)?.[0]?.[0]
+            setEmailSendError(errorMsg)
+          } else {
+            setEmailSendError('이메일 전송에 실패했습니다.')
+          }
         },
       }
     )
@@ -165,9 +170,14 @@ function SignupPage() {
           setIsSmsSent(true)
           setSmsSendError(null)
         },
-        onError: () => {
+        onError: (error) => {
           setIsSmsSent(false)
-          setSmsSendError('SMS 전송에 실패했습니다.')
+          if (error.statusCode === 400) {
+            const errorMsg = Object.values(error.error_detail)?.[0]?.[0]
+            setSmsSendError(errorMsg)
+          } else {
+            setSmsSendError('SMS 전송에 실패했습니다.')
+          }
         },
       }
     )

--- a/src/types/signup.ts
+++ b/src/types/signup.ts
@@ -1,4 +1,7 @@
-export type ReqInfo = Omit<SignupFormValues, 'password_confirm' | 'emailCode' | 'smsCode'>
+export type ReqInfo = Omit<
+  SignupFormValues,
+  'password_confirm' | 'emailCode' | 'smsCode'
+>
 
 export type ReqEmailOnly = Pick<SignupFormValues, 'email'>
 
@@ -51,6 +54,6 @@ export type ConflictError = {
 
 export type ApiError = ValidationError | ConflictError
 
-export type ResNickname = {
+export type ResDetail = {
   detail: string
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> 이슈 번호(#175)

- 이메일/전화번호 400 에러 메시지 화면 표시
## 📝 작업 내용

> 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능)
<img width="623" height="209" alt="Screenshot 2025-12-22 at 4 33 30 PM" src="https://github.com/user-attachments/assets/6501abc7-9f7b-42b8-8cd6-7dafbb8d0ecc" />

- 구현 기능 요약

- 주요 변경사항
  - 기존에는 에러 메시지를 고정값으로 사용하여, 이미 사용 중인 이메일임에도 불구하고 이메일 전송 중 오류가 발생했습니다라는 메시지가 노출되는 문제가 있었음
  - 400 응답 시 서버에서 내려주는 에러 메시지를 그대로 화면에 표시하도록 수정

## 🔍 테스트 항목

> 완료된 테스트 및 추가 테스트가 필요한 항목

- [ ] 테스트 1
- [ ] 테스트 2

## ✅ 체크리스트

> PR 작성 시 확인해야 할 사항

- [ ] 기능이 정상적으로 동작하는가?
- [ ] 코드 컨벤션을 준수하였는가?
- [ ] 불필요한 코드 (console.log, 미사용 변수 등)가 없는가?
- [ ] 가독성을 고려하여 적절한 주석을 추가하였는가?
- [ ] 브랜치를 main이 아닌 dev로 설정하였는가?

## 💬 기타

- 어려웠던 부분

- 고려해야할 부분
